### PR TITLE
feat: Update profile_id field in CapsuleSerializer

### DIFF
--- a/capsules/serializers.py
+++ b/capsules/serializers.py
@@ -61,7 +61,7 @@ class VideoSerializer(serializers.ModelSerializer):
 class CapsuleSerializer(serializers.ModelSerializer):
     owner = serializers.ReadOnlyField(source="owner.username")
     is_owner = serializers.SerializerMethodField()
-    profile_id = serializers.ReadOnlyField(source="agent_name.profile.id")
+    profile_id = serializers.ReadOnlyField(source="owner.profile.id")
     images = ImageSerializer(many=True, required=False)
     videos = VideoSerializer(many=True, required=False)
     like_id = serializers.SerializerMethodField()


### PR DESCRIPTION
The `profile_id` field in the `CapsuleSerializer` was updated to use the `owner.profile.id` as the source instead of `agent_name.profile.id`. This change ensures that the correct profile ID is retrieved for the capsule owner.