### PR TITLE
feat: Update permissions in Capsule views

### DIFF
--- a/capsules/views.py
+++ b/capsules/views.py
@@ -1,10 +1,10 @@
-from rest_framework import generics, filters
+from rest_framework import generics, filters, permissions
 from django_filters import rest_framework as filter
 from .models import Capsule, Images, Videos, GeminiMessage
 from .serializers import CapsuleSerializer, ImageSerializer, VideoSerializer, GeminiMessageSerializer
 from django.db.models import Count
 from django_filters.rest_framework import DjangoFilterBackend
-from memo_bubble.permissions import IsAdminUserOrReadOnly, IsOwnerOrReadOnly
+from memo_bubble.permissions import IsAdminUserOrReadOnly, IsAdminUserOrReadOnly
 
 
 class CapsuleFilter(filter.FilterSet):
@@ -25,7 +25,7 @@ class CapsuleList(generics.ListCreateAPIView):
         likes_count=Count('likes', distinct=True),
         capsule_count=Count("owner__capsule")).order_by("-capsule_count")
     serializer_class = CapsuleSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     filter_backends = [DjangoFilterBackend,
                        filters.SearchFilter, filters.OrderingFilter]
     filterset_class = CapsuleFilter
@@ -44,7 +44,7 @@ class CapsuleList(generics.ListCreateAPIView):
 class CapsuleDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Capsule.objects.all()
     serializer_class = CapsuleSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class ImageList(generics.ListCreateAPIView):
@@ -52,7 +52,7 @@ class ImageList(generics.ListCreateAPIView):
         return Images.objects.filter(capsule=self.kwargs["pk"])
 
     serializer_class = ImageSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class VideoList(generics.ListCreateAPIView):
@@ -60,7 +60,7 @@ class VideoList(generics.ListCreateAPIView):
         return Videos.objects.filter(capsule=self.kwargs["pk"])
 
     serializer_class = VideoSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class GeminiMessageList(generics.ListCreateAPIView):
@@ -75,13 +75,13 @@ class GeminiMessageList(generics.ListCreateAPIView):
             return GeminiMessage.objects.filter(video=self.kwargs["video_id"])
 
     serializer_class = GeminiMessageSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class ImageDelete(generics.RetrieveDestroyAPIView):
     queryset = Images.objects.all()
     serializer_class = ImageSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_object(self):
         # Retrieve the specific image by its ID
@@ -92,7 +92,7 @@ class ImageDelete(generics.RetrieveDestroyAPIView):
 class VideoDelete(generics.RetrieveDestroyAPIView):
     queryset = Videos.objects.all()
     serializer_class = VideoSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_object(self):
         # Retrieve the specific video by its ID
@@ -103,7 +103,7 @@ class VideoDelete(generics.RetrieveDestroyAPIView):
 class GeminiMessageDelete(generics.RetrieveDestroyAPIView):
     queryset = GeminiMessage.objects.all()
     serializer_class = GeminiMessageSerializer
-    permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_object(self):
         # Retrieve the specific gemini message by its ID


### PR DESCRIPTION
The permissions in the Capsule views were updated to use the `permissions.IsAuthenticatedOrReadOnly` class instead of the custom `IsOwnerOrReadOnly` permission class. This change ensures that only authenticated users can perform write operations on the Capsule endpoints, while allowing read operations for all users.