### PR TITLE
feat: Enable S3 Transfer Acceleration for presigned URLs

### DIFF
--- a/capsules/views.py
+++ b/capsules/views.py
@@ -125,7 +125,8 @@ class GeneratePresignedUrl(APIView):
             's3',
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            region_name=settings.AWS_S3_REGION_NAME
+            region_name=settings.AWS_S3_REGION_NAME,
+            config=boto3.session.Config(s3={'use_accelerate_endpoint': True})
         )
         file_name = request.query_params.get('file_name')
         response = s3_client.generate_presigned_post(


### PR DESCRIPTION

- Updated the GeneratePresignedUrl API view to use S3 Transfer Acceleration.
- Configured boto3 client with acceleration endpoint.
- Ensured Transfer Acceleration is enabled for the S3 bucket.
