### PR TITLE
Add mandatory 'location' field to Capsule model and update serializer

### DIFF
--- a/capsules/models.py
+++ b/capsules/models.py
@@ -6,6 +6,7 @@ class Capsule(models.Model):
     owner = models.ForeignKey(User, on_delete=models.CASCADE)
     title = models.CharField(max_length=255)
     message = models.TextField()
+    location = models.CharField(max_length=255, blank=False, null=False, default='Unknown')
     release_date = models.DateTimeField(null=True, blank=True)
     created_on = models.DateTimeField(auto_now_add=True)
     updated_on = models.DateTimeField(auto_now=True)

--- a/capsules/serializers.py
+++ b/capsules/serializers.py
@@ -133,6 +133,7 @@ class CapsuleSerializer(serializers.ModelSerializer):
 
         instance.title = validated_data.get("title", instance.title)
         instance.message = validated_data.get("message", instance.message)
+        instance.location = validated_data.get("location", instance.location)
         instance.release_date = validated_data.get(
             "release_date", instance.release_date)
         instance.save()
@@ -172,6 +173,7 @@ class CapsuleSerializer(serializers.ModelSerializer):
             "owner",
             "title",
             "message",
+            "location",
             "release_date",
             "created_on",
             "updated_on",


### PR DESCRIPTION
- Add 'location' field to Capsule model with  to enforce mandatory requirement.
- Update CapsuleSerializer to handle the 'location' field in update method.
- Include 'location' in the serializer's Meta fields to ensure it is processed in serialization and deserialization.