### PR TITLE
feat: Add view to retrieve Google Places Autocomplete suggestions

### DIFF
--- a/capsules/urls.py
+++ b/capsules/urls.py
@@ -28,4 +28,6 @@ urlpatterns = [
          name='save_video_metadata'),
     path('complete_multipart_upload/', views.CompleteMultipartUpload.as_view(),
          name='complete-multipart-upload'),
+     path('api/maps/place/', views.GetPlaceAutocomplete.as_view(),
+          name='place-autocomplete'),
 ]

--- a/capsules/views.py
+++ b/capsules/views.py
@@ -13,6 +13,7 @@ import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
 from django.http import JsonResponse
 from botocore.config import Config
+import requests
 
 
 AWS_ACCESS_KEY_ID = settings.AWS_ACCESS_KEY_ID
@@ -266,3 +267,17 @@ class SaveVideoMetadata(APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class GetPlaceAutocomplete(APIView):
+    def get(self, request, *args, **kwargs):
+        input_text = request.query_params.get('input', '')
+        api_key = settings.GOOGLE_MAPS_API_KEY
+
+        if not input_text:
+            return Response({"error": "Missing input parameter"}, status=400)
+
+        url = 'https://maps.googleapis.com/maps/api/place/autocomplete/json'
+        params = {'input': input_text, 'key': api_key}
+        response = requests.get(url, params=params)
+        return Response(response.json())

--- a/memo_bubble/settings.py
+++ b/memo_bubble/settings.py
@@ -162,6 +162,8 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'memo_bubble.wsgi.application'
 
+# Google Maps API
+GOOGLE_MAPS_API_KEY = os.environ.get('GOOGLE_MAPS_API_KEY')
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases


### PR DESCRIPTION
- Implement  view in  app to provide autocomplete suggestions for location searches.
- Update URL configuration to include new API endpoint for location search.
- Add handling for Google Maps API key in backend environment settings.
- Ensure API key is securely managed and not exposed in the frontend.

Additional setup:
- Add restrictions for Google Maps API key on Google Dev platform.